### PR TITLE
Added Placeholder for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +114,18 @@ name = "fussy-food"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rand",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -115,6 +139,21 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -132,6 +171,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -162,6 +231,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -235,3 +310,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ description = "A CLI tool for FussyFood operations"
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
+rand = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,65 @@
 use clap::{Parser, Subcommand};
+use rand::seq::SliceRandom;
 
 #[derive(Parser)]
-#[command(name = "fussyfood")]
-#[command(about = "FussyFood CLI tool for food-related operations", long_about = None)]
+#[command(name = "fussy-food")]
+#[command(about = "A CLI tool for helping us manage our toddler's meals.", long_about = "A CLI tool for helping us manage our family's meals. We want a place that can help us find recipes, come up with ideas for meals, and help us manage the meal plan for a toddler.", version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum MealType {
+    Breakfast = 1,
+    Lunch = 2,
+    Dinner = 3,
+    Snack = 7,
+}
+
 #[derive(Subcommand)]
 enum Commands {
-    /// Performs a sample operation
-    Sample {
-        /// Name of the person to greet
-        #[arg(short, long)]
-        name: String,
+    /// Manage toddler meal planning
+    Toddler {
+        /// Type of meal to plan (breakfast=1, lunch=2, dinner=3, snack=7)
+        #[arg(short, long, value_enum)]
+        meal: MealType,
     },
+}
+
+fn get_random_fruit() -> &'static str {
+    let fruits = ["apple", "banana", "orange", "strawberry", "blueberry"];
+    fruits.choose(&mut rand::thread_rng()).unwrap()
+}
+
+fn breakfast_suggestion() -> &'static str {
+    get_random_fruit()
+}
+
+fn lunch_suggestion() -> &'static str {
+    get_random_fruit()
+}
+
+fn dinner_suggestion() -> &'static str {
+    get_random_fruit()
+}
+
+fn snack_suggestion() -> &'static str {
+    get_random_fruit()
 }
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Sample { name } => {
-            println!("Hello, {}! Welcome to FussyFood!", name);
+        Commands::Toddler { meal } => {
+            let suggestion = match meal {
+                MealType::Breakfast => breakfast_suggestion(),
+                MealType::Lunch => lunch_suggestion(),
+                MealType::Dinner => dinner_suggestion(),
+                MealType::Snack => snack_suggestion(),
+            };
+            println!("Suggested fruit for {:?}: {}", meal, suggestion);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `fussy-food` CLI tool, including the addition of a new dependency, updates to the command structure, and new functions for meal suggestions.

Dependency updates:
* Added the `rand` crate to `Cargo.toml` to support random selection functionality.

Command structure updates:
* Renamed the CLI tool to `fussy-food` and updated its description to better reflect its purpose of managing family meals, particularly for toddlers.
* Introduced a new `MealType` enum to specify the type of meal (breakfast, lunch, dinner, snack) in the `Toddler` command.

New functionality:
* Added functions to suggest random fruits for different meal types (`breakfast_suggestion`, `lunch_suggestion`, `dinner_suggestion`, `snack_suggestion`). These functions use the `rand` crate to choose a fruit randomly.

These changes enhance the functionality of the CLI tool, making it more useful for meal planning by providing random fruit suggestions for different meal types.